### PR TITLE
Copying bug fix

### DIFF
--- a/server/updateServer.js
+++ b/server/updateServer.js
@@ -53,7 +53,7 @@ function update(repo, branch) {
 
 function copyPrivateToTemp(repo, branch, notify) {
   notify("Copying private to temp");
-  exec('cp -R ' + privateDir(repo) + ' ' + tempDir(repo), (err, stdOut, stdErr) => {
+  exec('cp -RT ' + privateDir(repo) + ' ' + tempDir(repo), (err, stdOut, stdErr) => {
     if (err) {
       console.error(err);
     }
@@ -121,7 +121,7 @@ function installClientDependencies(repo, branch, notify) {
 
 function copyTempToPrivate(repo, branch, notify) {
   notify("Copying temp to private")
-  exec('cp -R ' + tempDir(repo) + ' ' + privateDir(repo), (err, stdOut, stdErr) => {
+  exec('cp -RT ' + tempDir(repo) + ' ' + privateDir(repo), (err, stdOut, stdErr) => {
     if (err) {
       console.error(err);
     }


### PR DESCRIPTION
Fix inconsistency while copying. When destination folder exists copies private folder into it where as when destination folder does not exists creates and copies private folder contents to it.